### PR TITLE
updating CI file

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,55 +3,67 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-
-  lint:
-    name: Lint
+  check:
+    name: Check
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout the source code
+      - name: Checkout sources
         uses: actions/checkout@master
 
-      - name: Install Rust stable
-        run: |
-          rustup toolchain update --no-self-update stable
-          rustup default stable
-          rustup component add clippy rustfmt
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
 
-      - name: Run rustfmt
-        run: cargo fmt -- --check
-
-      - name: Run clippy
-        run: cargo clippy --all --all-features --
+      - name: Run cargo check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
 
   test:
-    name: Test
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest]
-        cargo_flags:
-          - ""
-          - "--all-features"
-        include:
-          # Integration tests are disabled on Windows as they take *way* too
-          # long to pull the Docker image
-          - os: windows-latest
-            test_flags: --skip buildtest --skip integration
+    name: Test Suite
+    runs-on: ubuntu-latest
     steps:
-      - name: Checkout the source code
+      - name: Checkout sources
         uses: actions/checkout@master
 
-      - name: Install Rust stable
-        run: |
-          rustup toolchain update --no-self-update stable
-          rustup default stable
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
 
-      - name: Build rustwide
-        run: 
-          cargo update
-          cargo build --all ${{ matrix.cargo_flags }}
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
 
-      - name: Test rustwide
-        run: 
-          cargo update
-          cargo test --all ${{ matrix.cargo_flags }} -- ${{ matrix.test_flags }}
+  lints:
+    name: Lints
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@master
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+
+      - name: Run cargo fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+      - name: Run cargo clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,12 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+          
+      - name: Install nightly toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
 
       - name: Run cargo check
         uses: actions-rs/cargo@v1
@@ -35,6 +41,12 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+      
+      - name: Install nightly toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1
@@ -55,6 +67,13 @@ jobs:
           toolchain: stable
           override: true
           components: rustfmt, clippy
+          
+      - name: Install nightly toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
 
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -73,13 +73,6 @@ jobs:
           toolchain: stable
           override: true
           components: rustfmt, clippy
-          
-      - name: Install nightly toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
 
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,6 +22,12 @@ jobs:
         with:
           profile: minimal
           toolchain: nightly
+          
+      - name: Install WASM toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: wasm32-unknown-unknown
 
       - name: Run cargo check
         uses: actions-rs/cargo@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,10 +24,7 @@ jobs:
           toolchain: nightly
           
       - name: Install WASM toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: wasm32-unknown-unknown
+        run: rustup target add wasm32-unknown-unknown --toolchain nightly
 
       - name: Run cargo check
         uses: actions-rs/cargo@v1
@@ -53,6 +50,9 @@ jobs:
         with:
           profile: minimal
           toolchain: nightly
+          
+      - name: Install WASM toolchain
+        run: rustup target add wasm32-unknown-unknown --toolchain nightly
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
- Using cargo check vs. build command due to "This will essentially compile the packages without performing the final step of code generation, which is faster than running cargo build." from the cargo documentation.

- The lint test is failing due to formatting suggestions which need applying without --check parameter and resubmitting source.