### PR TITLE
feat: Relates to MMD-724 / Add hardware mining max token bonus per gateway for use with sidecar

### DIFF
--- a/custom_types.json
+++ b/custom_types.json
@@ -1,7 +1,7 @@
 {
   "Keys": "SessionKeys2",
-  "Address": "AccountId", 
-  "LookupSource": "AccountId", 
+  "Address": "AccountId",
+  "LookupSource": "AccountId",
   "RoamingOperator": "[u8; 16]",
   "RoamingOperatorIndex": "u64",
   "RoamingNetwork": "[u8; 16]",
@@ -116,10 +116,16 @@
   "MiningSpeedBoostRatesHardwareMiningHardwareSecure": "u32",
   "MiningSpeedBoostRatesHardwareMiningHardwareInsecure": "u32",
   "MiningSpeedBoostRatesHardwareMiningMaxHardware": "u32",
+  "MiningSpeedBoostRatesHardwareMiningCategory1MaxTokenBonusPerGateway": "u32",
+  "MiningSpeedBoostRatesHardwareMiningCategory2MaxTokenBonusPerGateway": "u32",
+  "MiningSpeedBoostRatesHardwareMiningCategory3MaxTokenBonusPerGateway": "u32",
   "MiningSpeedBoostRatesHardwareMiningRatesConfig": {
     "hardware_hardware_secure": "u32",
     "hardware_hardware_insecure": "u32",
-    "hardware_max_hardware": "u32"
+    "hardware_max_hardware": "u32",
+    "hardware_category_1_max_token_bonus_per_gateway": "u32",
+    "hardware_category_2_max_token_bonus_per_gateway": "u32",
+    "hardware_category_3_max_token_bonus_per_gateway": "u32"
   },
   "MiningSpeedBoostConfigurationTokenMining": "[u8; 16]",
   "MiningSpeedBoostConfigurationTokenMiningIndex": "u64",

--- a/pallets/mining/mining-speed-boosts/eligibility/hardware-mining/src/mock.rs
+++ b/pallets/mining/mining-speed-boosts/eligibility/hardware-mining/src/mock.rs
@@ -92,15 +92,15 @@ impl roaming_operators::Trait for Test {
 }
 impl mining_speed_boosts_rates_hardware_mining::Trait for Test {
     type Event = ();
+    type MiningSpeedBoostRatesHardwareMiningCategory1MaxTokenBonusPerGateway = u32;
+    type MiningSpeedBoostRatesHardwareMiningCategory2MaxTokenBonusPerGateway = u32;
+    type MiningSpeedBoostRatesHardwareMiningCategory3MaxTokenBonusPerGateway = u32;
     type MiningSpeedBoostRatesHardwareMiningHardwareInsecure = u32;
     // Mining Speed Boost Rate
     type MiningSpeedBoostRatesHardwareMiningHardwareSecure = u32;
     type MiningSpeedBoostRatesHardwareMiningIndex = u64;
     // Mining Speed Boost Max Rates
     type MiningSpeedBoostRatesHardwareMiningMaxHardware = u32;
-    type MiningSpeedBoostRatesHardwareMiningCategory1MaxTokenBonusPerGateway = u32;
-    type MiningSpeedBoostRatesHardwareMiningCategory2MaxTokenBonusPerGateway = u32;
-    type MiningSpeedBoostRatesHardwareMiningCategory3MaxTokenBonusPerGateway = u32;
 }
 impl mining_speed_boosts_sampling_hardware_mining::Trait for Test {
     type Event = ();

--- a/pallets/mining/mining-speed-boosts/eligibility/hardware-mining/src/mock.rs
+++ b/pallets/mining/mining-speed-boosts/eligibility/hardware-mining/src/mock.rs
@@ -98,6 +98,9 @@ impl mining_speed_boosts_rates_hardware_mining::Trait for Test {
     type MiningSpeedBoostRatesHardwareMiningIndex = u64;
     // Mining Speed Boost Max Rates
     type MiningSpeedBoostRatesHardwareMiningMaxHardware = u32;
+    type MiningSpeedBoostRatesHardwareMiningCategory1MaxTokenBonusPerGateway = u32;
+    type MiningSpeedBoostRatesHardwareMiningCategory2MaxTokenBonusPerGateway = u32;
+    type MiningSpeedBoostRatesHardwareMiningCategory3MaxTokenBonusPerGateway = u32;
 }
 impl mining_speed_boosts_sampling_hardware_mining::Trait for Test {
     type Event = ();

--- a/pallets/mining/mining-speed-boosts/lodgements/hardware-mining/src/mock.rs
+++ b/pallets/mining/mining-speed-boosts/lodgements/hardware-mining/src/mock.rs
@@ -117,15 +117,15 @@ impl mining_speed_boosts_eligibility_hardware_mining::Trait for Test {
 }
 impl mining_speed_boosts_rates_hardware_mining::Trait for Test {
     type Event = ();
+    type MiningSpeedBoostRatesHardwareMiningCategory1MaxTokenBonusPerGateway = u32;
+    type MiningSpeedBoostRatesHardwareMiningCategory2MaxTokenBonusPerGateway = u32;
+    type MiningSpeedBoostRatesHardwareMiningCategory3MaxTokenBonusPerGateway = u32;
     type MiningSpeedBoostRatesHardwareMiningHardwareInsecure = u32;
     // Mining Speed Boost Rate
     type MiningSpeedBoostRatesHardwareMiningHardwareSecure = u32;
     type MiningSpeedBoostRatesHardwareMiningIndex = u64;
     // Mining Speed Boost Max Rates
     type MiningSpeedBoostRatesHardwareMiningMaxHardware = u32;
-    type MiningSpeedBoostRatesHardwareMiningCategory1MaxTokenBonusPerGateway = u32;
-    type MiningSpeedBoostRatesHardwareMiningCategory2MaxTokenBonusPerGateway = u32;
-    type MiningSpeedBoostRatesHardwareMiningCategory3MaxTokenBonusPerGateway = u32;
 }
 impl mining_speed_boosts_sampling_hardware_mining::Trait for Test {
     type Event = ();

--- a/pallets/mining/mining-speed-boosts/lodgements/hardware-mining/src/mock.rs
+++ b/pallets/mining/mining-speed-boosts/lodgements/hardware-mining/src/mock.rs
@@ -123,6 +123,9 @@ impl mining_speed_boosts_rates_hardware_mining::Trait for Test {
     type MiningSpeedBoostRatesHardwareMiningIndex = u64;
     // Mining Speed Boost Max Rates
     type MiningSpeedBoostRatesHardwareMiningMaxHardware = u32;
+    type MiningSpeedBoostRatesHardwareMiningCategory1MaxTokenBonusPerGateway = u32;
+    type MiningSpeedBoostRatesHardwareMiningCategory2MaxTokenBonusPerGateway = u32;
+    type MiningSpeedBoostRatesHardwareMiningCategory3MaxTokenBonusPerGateway = u32;
 }
 impl mining_speed_boosts_sampling_hardware_mining::Trait for Test {
     type Event = ();

--- a/pallets/mining/mining-speed-boosts/rates/hardware-mining/src/lib.rs
+++ b/pallets/mining/mining-speed-boosts/rates/hardware-mining/src/lib.rs
@@ -49,9 +49,24 @@ pub trait Trait: frame_system::Trait + roaming_operators::Trait {
         + Default
         + Copy;
     type MiningSpeedBoostRatesHardwareMiningMaxHardware: Parameter + Member + AtLeast32Bit + Bounded + Default + Copy;
-    type MiningSpeedBoostRatesHardwareMiningCategory1MaxTokenBonusPerGateway: Parameter + Member + AtLeast32Bit + Bounded + Default + Copy;
-    type MiningSpeedBoostRatesHardwareMiningCategory2MaxTokenBonusPerGateway: Parameter + Member + AtLeast32Bit + Bounded + Default + Copy;
-    type MiningSpeedBoostRatesHardwareMiningCategory3MaxTokenBonusPerGateway: Parameter + Member + AtLeast32Bit + Bounded + Default + Copy;
+    type MiningSpeedBoostRatesHardwareMiningCategory1MaxTokenBonusPerGateway: Parameter
+        + Member
+        + AtLeast32Bit
+        + Bounded
+        + Default
+        + Copy;
+    type MiningSpeedBoostRatesHardwareMiningCategory2MaxTokenBonusPerGateway: Parameter
+        + Member
+        + AtLeast32Bit
+        + Bounded
+        + Default
+        + Copy;
+    type MiningSpeedBoostRatesHardwareMiningCategory3MaxTokenBonusPerGateway: Parameter
+        + Member
+        + AtLeast32Bit
+        + Bounded
+        + Default
+        + Copy;
 }
 
 // type BalanceOf<T> = <<T as roaming_operators::Trait>::Currency as Currency<<T as

--- a/pallets/mining/mining-speed-boosts/rates/hardware-mining/src/lib.rs
+++ b/pallets/mining/mining-speed-boosts/rates/hardware-mining/src/lib.rs
@@ -49,6 +49,9 @@ pub trait Trait: frame_system::Trait + roaming_operators::Trait {
         + Default
         + Copy;
     type MiningSpeedBoostRatesHardwareMiningMaxHardware: Parameter + Member + AtLeast32Bit + Bounded + Default + Copy;
+    type MiningSpeedBoostRatesHardwareMiningCategory1MaxTokenBonusPerGateway: Parameter + Member + AtLeast32Bit + Bounded + Default + Copy;
+    type MiningSpeedBoostRatesHardwareMiningCategory2MaxTokenBonusPerGateway: Parameter + Member + AtLeast32Bit + Bounded + Default + Copy;
+    type MiningSpeedBoostRatesHardwareMiningCategory3MaxTokenBonusPerGateway: Parameter + Member + AtLeast32Bit + Bounded + Default + Copy;
 }
 
 // type BalanceOf<T> = <<T as roaming_operators::Trait>::Currency as Currency<<T as
@@ -60,10 +63,13 @@ pub struct MiningSpeedBoostRatesHardwareMining(pub [u8; 16]);
 
 #[cfg_attr(feature = "std", derive(Debug))]
 #[derive(Encode, Decode, Default, Clone, PartialEq)]
-pub struct MiningSpeedBoostRatesHardwareMiningRatesConfig<U, V, W> {
+pub struct MiningSpeedBoostRatesHardwareMiningRatesConfig<U, V, W, X, Y, Z> {
     pub hardware_hardware_secure: U,
     pub hardware_hardware_insecure: V,
     pub hardware_max_hardware: W,
+    pub hardware_category_1_max_token_bonus_per_gateway: X,
+    pub hardware_category_2_max_token_bonus_per_gateway: Y,
+    pub hardware_category_3_max_token_bonus_per_gateway: Z,
 }
 
 decl_event!(
@@ -73,6 +79,9 @@ decl_event!(
         <T as Trait>::MiningSpeedBoostRatesHardwareMiningHardwareSecure,
         <T as Trait>::MiningSpeedBoostRatesHardwareMiningHardwareInsecure,
         <T as Trait>::MiningSpeedBoostRatesHardwareMiningMaxHardware,
+        <T as Trait>::MiningSpeedBoostRatesHardwareMiningCategory1MaxTokenBonusPerGateway,
+        <T as Trait>::MiningSpeedBoostRatesHardwareMiningCategory2MaxTokenBonusPerGateway,
+        <T as Trait>::MiningSpeedBoostRatesHardwareMiningCategory3MaxTokenBonusPerGateway,
         // Balance = BalanceOf<T>,
     {
         /// A mining_speed_boosts_rates_hardware_mining is created. (owner, mining_speed_boosts_rates_hardware_mining_id)
@@ -81,7 +90,10 @@ decl_event!(
         Transferred(AccountId, AccountId, MiningSpeedBoostRatesHardwareMiningIndex),
         MiningSpeedBoostRatesHardwareMiningRatesConfigSet(
             AccountId, MiningSpeedBoostRatesHardwareMiningIndex, MiningSpeedBoostRatesHardwareMiningHardwareSecure,
-            MiningSpeedBoostRatesHardwareMiningHardwareInsecure, MiningSpeedBoostRatesHardwareMiningMaxHardware
+            MiningSpeedBoostRatesHardwareMiningHardwareInsecure, MiningSpeedBoostRatesHardwareMiningMaxHardware,
+            MiningSpeedBoostRatesHardwareMiningCategory1MaxTokenBonusPerGateway,
+            MiningSpeedBoostRatesHardwareMiningCategory2MaxTokenBonusPerGateway,
+            MiningSpeedBoostRatesHardwareMiningCategory3MaxTokenBonusPerGateway
         ),
     }
 );
@@ -101,7 +113,10 @@ decl_storage! {
         /// Stores mining_speed_boosts_rates_hardware_mining_rates_config
         pub MiningSpeedBoostRatesHardwareMiningRatesConfigs get(fn mining_speed_boosts_rates_hardware_mining_rates_configs): map hasher(opaque_blake2_256) T::MiningSpeedBoostRatesHardwareMiningIndex =>
             Option<MiningSpeedBoostRatesHardwareMiningRatesConfig<T::MiningSpeedBoostRatesHardwareMiningHardwareSecure,
-            T::MiningSpeedBoostRatesHardwareMiningHardwareInsecure, T::MiningSpeedBoostRatesHardwareMiningMaxHardware>>;
+            T::MiningSpeedBoostRatesHardwareMiningHardwareInsecure, T::MiningSpeedBoostRatesHardwareMiningMaxHardware,
+            T::MiningSpeedBoostRatesHardwareMiningCategory1MaxTokenBonusPerGateway,
+            T::MiningSpeedBoostRatesHardwareMiningCategory2MaxTokenBonusPerGateway,
+            T::MiningSpeedBoostRatesHardwareMiningCategory3MaxTokenBonusPerGateway>>;
     }
 }
 
@@ -146,7 +161,10 @@ decl_module! {
             mining_speed_boosts_rates_hardware_mining_id: T::MiningSpeedBoostRatesHardwareMiningIndex,
             _hardware_hardware_secure: Option<T::MiningSpeedBoostRatesHardwareMiningHardwareSecure>,
             _hardware_hardware_insecure: Option<T::MiningSpeedBoostRatesHardwareMiningHardwareInsecure>,
-            _hardware_max_hardware: Option<T::MiningSpeedBoostRatesHardwareMiningMaxHardware>
+            _hardware_max_hardware: Option<T::MiningSpeedBoostRatesHardwareMiningMaxHardware>,
+            _hardware_category_1_max_token_bonus_per_gateway: Option<T::MiningSpeedBoostRatesHardwareMiningCategory1MaxTokenBonusPerGateway>,
+            _hardware_category_2_max_token_bonus_per_gateway: Option<T::MiningSpeedBoostRatesHardwareMiningCategory2MaxTokenBonusPerGateway>,
+            _hardware_category_3_max_token_bonus_per_gateway: Option<T::MiningSpeedBoostRatesHardwareMiningCategory3MaxTokenBonusPerGateway>
         ) {
             let sender = ensure_signed(origin)?;
 
@@ -170,6 +188,18 @@ decl_module! {
               Some(value) => value,
               None => 1.into() // Default
             };
+            let hardware_category_1_max_token_bonus_per_gateway = match _hardware_category_1_max_token_bonus_per_gateway.clone() {
+                Some(value) => value,
+                None => 1000000.into() // Default
+            };
+            let hardware_category_2_max_token_bonus_per_gateway = match _hardware_category_2_max_token_bonus_per_gateway {
+                Some(value) => value,
+                None => 500000.into() // Default
+            };
+            let hardware_category_3_max_token_bonus_per_gateway = match _hardware_category_3_max_token_bonus_per_gateway {
+                Some(value) => value,
+                None => 250000.into() // Default
+            };
 
             // Check if a mining_speed_boosts_rates_hardware_mining_rates_config already exists with the given mining_speed_boosts_rates_hardware_mining_id
             // to determine whether to insert new or mutate existing.
@@ -181,6 +211,9 @@ decl_module! {
                         _mining_speed_boosts_rates_hardware_mining_rates_config.hardware_hardware_secure = hardware_hardware_secure.clone();
                         _mining_speed_boosts_rates_hardware_mining_rates_config.hardware_hardware_insecure = hardware_hardware_insecure.clone();
                         _mining_speed_boosts_rates_hardware_mining_rates_config.hardware_max_hardware = hardware_max_hardware.clone();
+                        _mining_speed_boosts_rates_hardware_mining_rates_config.hardware_category_1_max_token_bonus_per_gateway = hardware_category_1_max_token_bonus_per_gateway.clone();
+                        _mining_speed_boosts_rates_hardware_mining_rates_config.hardware_category_2_max_token_bonus_per_gateway = hardware_category_2_max_token_bonus_per_gateway.clone();
+                        _mining_speed_boosts_rates_hardware_mining_rates_config.hardware_category_3_max_token_bonus_per_gateway = hardware_category_3_max_token_bonus_per_gateway.clone();
                     }
                 });
                 debug::info!("Checking mutated values");
@@ -189,6 +222,9 @@ decl_module! {
                     debug::info!("Latest field hardware_hardware_secure {:#?}", _mining_speed_boosts_rates_hardware_mining_rates_config.hardware_hardware_secure);
                     debug::info!("Latest field hardware_hardware_insecure {:#?}", _mining_speed_boosts_rates_hardware_mining_rates_config.hardware_hardware_insecure);
                     debug::info!("Latest field hardware_max_hardware {:#?}", _mining_speed_boosts_rates_hardware_mining_rates_config.hardware_max_hardware);
+                    debug::info!("Latest field hardware_category_1_max_token_bonus_per_gateway {:#?}", _mining_speed_boosts_rates_hardware_mining_rates_config.hardware_category_1_max_token_bonus_per_gateway);
+                    debug::info!("Latest field hardware_category_2_max_token_bonus_per_gateway {:#?}", _mining_speed_boosts_rates_hardware_mining_rates_config.hardware_category_2_max_token_bonus_per_gateway);
+                    debug::info!("Latest field hardware_category_3_max_token_bonus_per_gateway {:#?}", _mining_speed_boosts_rates_hardware_mining_rates_config.hardware_category_3_max_token_bonus_per_gateway);
                 }
             } else {
                 debug::info!("Inserting values");
@@ -200,6 +236,9 @@ decl_module! {
                     hardware_hardware_secure: hardware_hardware_secure.clone(),
                     hardware_hardware_insecure: hardware_hardware_insecure.clone(),
                     hardware_max_hardware: hardware_max_hardware.clone(),
+                    hardware_category_1_max_token_bonus_per_gateway: hardware_category_1_max_token_bonus_per_gateway.clone(),
+                    hardware_category_2_max_token_bonus_per_gateway: hardware_category_2_max_token_bonus_per_gateway.clone(),
+                    hardware_category_3_max_token_bonus_per_gateway: hardware_category_3_max_token_bonus_per_gateway.clone(),
                 };
 
                 <MiningSpeedBoostRatesHardwareMiningRatesConfigs<T>>::insert(
@@ -213,6 +252,9 @@ decl_module! {
                     debug::info!("Inserted field hardware_hardware_secure {:#?}", _mining_speed_boosts_rates_hardware_mining_rates_config.hardware_hardware_secure);
                     debug::info!("Inserted field hardware_hardware_insecure {:#?}", _mining_speed_boosts_rates_hardware_mining_rates_config.hardware_hardware_insecure);
                     debug::info!("Inserted field hardware_max_hardware {:#?}", _mining_speed_boosts_rates_hardware_mining_rates_config.hardware_max_hardware);
+                    debug::info!("Inserted field hardware_category_1_max_token_bonus_per_gateway {:#?}", _mining_speed_boosts_rates_hardware_mining_rates_config.hardware_category_1_max_token_bonus_per_gateway);
+                    debug::info!("Inserted field hardware_category_2_max_token_bonus_per_gateway {:#?}", _mining_speed_boosts_rates_hardware_mining_rates_config.hardware_category_2_max_token_bonus_per_gateway);
+                    debug::info!("Inserted field hardware_category_3_max_token_bonus_per_gateway {:#?}", _mining_speed_boosts_rates_hardware_mining_rates_config.hardware_category_3_max_token_bonus_per_gateway);
                 }
             }
 
@@ -222,6 +264,9 @@ decl_module! {
                 hardware_hardware_secure,
                 hardware_hardware_insecure,
                 hardware_max_hardware,
+                hardware_category_1_max_token_bonus_per_gateway,
+                hardware_category_2_max_token_bonus_per_gateway,
+                hardware_category_3_max_token_bonus_per_gateway,
             ));
         }
     }

--- a/pallets/mining/mining-speed-boosts/rates/hardware-mining/src/mock.rs
+++ b/pallets/mining/mining-speed-boosts/rates/hardware-mining/src/mock.rs
@@ -96,6 +96,9 @@ impl Trait for Test {
     type MiningSpeedBoostRatesHardwareMiningHardwareSecure = u32;
     type MiningSpeedBoostRatesHardwareMiningIndex = u64;
     type MiningSpeedBoostRatesHardwareMiningMaxHardware = u32;
+    type MiningSpeedBoostRatesHardwareMiningCategory1MaxTokenBonusPerGateway = u32;
+    type MiningSpeedBoostRatesHardwareMiningCategory2MaxTokenBonusPerGateway = u32;
+    type MiningSpeedBoostRatesHardwareMiningCategory3MaxTokenBonusPerGateway = u32;
 }
 type System = frame_system::Module<Test>;
 pub type Balances = pallet_balances::Module<Test>;

--- a/pallets/mining/mining-speed-boosts/rates/hardware-mining/src/mock.rs
+++ b/pallets/mining/mining-speed-boosts/rates/hardware-mining/src/mock.rs
@@ -92,13 +92,13 @@ impl roaming_operators::Trait for Test {
 }
 impl Trait for Test {
     type Event = ();
+    type MiningSpeedBoostRatesHardwareMiningCategory1MaxTokenBonusPerGateway = u32;
+    type MiningSpeedBoostRatesHardwareMiningCategory2MaxTokenBonusPerGateway = u32;
+    type MiningSpeedBoostRatesHardwareMiningCategory3MaxTokenBonusPerGateway = u32;
     type MiningSpeedBoostRatesHardwareMiningHardwareInsecure = u32;
     type MiningSpeedBoostRatesHardwareMiningHardwareSecure = u32;
     type MiningSpeedBoostRatesHardwareMiningIndex = u64;
     type MiningSpeedBoostRatesHardwareMiningMaxHardware = u32;
-    type MiningSpeedBoostRatesHardwareMiningCategory1MaxTokenBonusPerGateway = u32;
-    type MiningSpeedBoostRatesHardwareMiningCategory2MaxTokenBonusPerGateway = u32;
-    type MiningSpeedBoostRatesHardwareMiningCategory3MaxTokenBonusPerGateway = u32;
 }
 type System = frame_system::Module<Test>;
 pub type Balances = pallet_balances::Module<Test>;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -668,6 +668,9 @@ impl mining_speed_boosts_rates_hardware_mining::Trait for Runtime {
     type MiningSpeedBoostRatesHardwareMiningIndex = u64;
     // Mining Speed Boost Max Rates
     type MiningSpeedBoostRatesHardwareMiningMaxHardware = u32;
+    type MiningSpeedBoostRatesHardwareMiningCategory1MaxTokenBonusPerGateway = u32;
+    type MiningSpeedBoostRatesHardwareMiningCategory2MaxTokenBonusPerGateway = u32;
+    type MiningSpeedBoostRatesHardwareMiningCategory3MaxTokenBonusPerGateway = u32;
 }
 
 impl mining_speed_boosts_sampling_token_mining::Trait for Runtime {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -662,15 +662,15 @@ impl mining_speed_boosts_rates_token_mining::Trait for Runtime {
 
 impl mining_speed_boosts_rates_hardware_mining::Trait for Runtime {
     type Event = Event;
+    type MiningSpeedBoostRatesHardwareMiningCategory1MaxTokenBonusPerGateway = u32;
+    type MiningSpeedBoostRatesHardwareMiningCategory2MaxTokenBonusPerGateway = u32;
+    type MiningSpeedBoostRatesHardwareMiningCategory3MaxTokenBonusPerGateway = u32;
     type MiningSpeedBoostRatesHardwareMiningHardwareInsecure = u32;
     // Mining Speed Boost Rate
     type MiningSpeedBoostRatesHardwareMiningHardwareSecure = u32;
     type MiningSpeedBoostRatesHardwareMiningIndex = u64;
     // Mining Speed Boost Max Rates
     type MiningSpeedBoostRatesHardwareMiningMaxHardware = u32;
-    type MiningSpeedBoostRatesHardwareMiningCategory1MaxTokenBonusPerGateway = u32;
-    type MiningSpeedBoostRatesHardwareMiningCategory2MaxTokenBonusPerGateway = u32;
-    type MiningSpeedBoostRatesHardwareMiningCategory3MaxTokenBonusPerGateway = u32;
 }
 
 impl mining_speed_boosts_sampling_token_mining::Trait for Runtime {

--- a/runtime/tests/cli_integration_tests_mining_hardware.rs
+++ b/runtime/tests/cli_integration_tests_mining_hardware.rs
@@ -148,15 +148,15 @@ mod tests {
     }
     impl MiningSpeedBoostRatesHardwareMiningTrait for Test {
         type Event = ();
+        type MiningSpeedBoostRatesHardwareMiningCategory1MaxTokenBonusPerGateway = u32;
+        type MiningSpeedBoostRatesHardwareMiningCategory2MaxTokenBonusPerGateway = u32;
+        type MiningSpeedBoostRatesHardwareMiningCategory3MaxTokenBonusPerGateway = u32;
         type MiningSpeedBoostRatesHardwareMiningHardwareInsecure = u32;
         // Mining Speed Boost Rate
         type MiningSpeedBoostRatesHardwareMiningHardwareSecure = u32;
         type MiningSpeedBoostRatesHardwareMiningIndex = u64;
         // Mining Speed Boost Max Rates
         type MiningSpeedBoostRatesHardwareMiningMaxHardware = u32;
-        type MiningSpeedBoostRatesHardwareMiningCategory1MaxTokenBonusPerGateway = u32;
-        type MiningSpeedBoostRatesHardwareMiningCategory2MaxTokenBonusPerGateway = u32;
-        type MiningSpeedBoostRatesHardwareMiningCategory3MaxTokenBonusPerGateway = u32;
     }
     impl MiningSpeedBoostSamplingHardwareMiningTrait for Test {
         type Event = ();

--- a/runtime/tests/cli_integration_tests_mining_hardware.rs
+++ b/runtime/tests/cli_integration_tests_mining_hardware.rs
@@ -154,6 +154,9 @@ mod tests {
         type MiningSpeedBoostRatesHardwareMiningIndex = u64;
         // Mining Speed Boost Max Rates
         type MiningSpeedBoostRatesHardwareMiningMaxHardware = u32;
+        type MiningSpeedBoostRatesHardwareMiningCategory1MaxTokenBonusPerGateway = u32;
+        type MiningSpeedBoostRatesHardwareMiningCategory2MaxTokenBonusPerGateway = u32;
+        type MiningSpeedBoostRatesHardwareMiningCategory3MaxTokenBonusPerGateway = u32;
     }
     impl MiningSpeedBoostSamplingHardwareMiningTrait for Test {
         type Event = ();
@@ -231,6 +234,9 @@ mod tests {
                 Some(1), // hardware_hardware_secure
                 Some(1), // hardware_hardware_insecure
                 Some(1), // hardware_max_hardware
+                Some(1000000),
+                Some(500000),
+                Some(250000)
               )
             );
 
@@ -244,6 +250,9 @@ mod tests {
                     hardware_hardware_secure: 1,
                     hardware_hardware_insecure: 1,
                     hardware_max_hardware: 1,
+                    hardware_category_1_max_token_bonus_per_gateway: 1000000,
+                    hardware_category_2_max_token_bonus_per_gateway: 500000,
+                    hardware_category_3_max_token_bonus_per_gateway: 250000
                 })
             );
 


### PR DESCRIPTION
Allows for querying from sidecar API endpoints by following the steps in its readme https://github.com/DataHighway-DHX/substrate-api-sidecar#quickstart, which relates to this PR that's been merged https://github.com/DataHighway-DHX/substrate-api-sidecar/pull/5

Note that this is to check it works, then next step is to:
* Fix so we are using the correct types (i.e. so we can store float values)
* Refactor if possible (we don't need all the debug statements that I've included in this PR), shorter variable names, storage
* Since there's always going to be a config, it would be ideal to combine the creation of a rating with settings its config into a single API call 
i.e. both `MiningSpeedBoostRatesHardwareMiningTestModule::create(Origin::signed(0)));
MiningSpeedBoostRatesHardwareMiningTestModule::set_mining_speed_boosts_rates_hardware_mining_rates_config`