### PR TITLE
feat: Add membership supernodes pallet loosely coupled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,6 +11,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "account-set"
+version = "2.0.0"
+dependencies = [
+ "sp-std",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -994,6 +1001,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "frame-system-rpc-runtime-api",
+ "membership-supernodes",
  "mining-claims-hardware",
  "mining-claims-token",
  "mining-config-hardware",
@@ -3096,6 +3104,20 @@ name = "maybe-uninit"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
+
+[[package]]
+name = "membership-supernodes"
+version = "2.0.0"
+dependencies = [
+ "account-set",
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
 
 [[package]]
 name = "memchr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     'pallets/roaming/roaming-billing-policies',
     'pallets/roaming/roaming-charging-policies',
     'pallets/roaming/roaming-packet-bundles',
+    'pallets/membership/supernodes',
     'pallets/mining/config/token',
     'pallets/mining/config/hardware',
     'pallets/mining/rates/token',

--- a/pallets/membership/supernodes/Cargo.toml
+++ b/pallets/membership/supernodes/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "membership-supernodes"
+version = "2.0.0"
+edition = "2018"
+repository = 'https://github.com/substrate-developer-hub/recipes'
+authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
+description = "Fork of Substrate Recipe pallet vec-set. A pallet that implements a storage Set on top of a Vec"
+license = "GPL-3.0-or-later"
+
+[package.metadata.substrate]
+categories = [
+	"pallet",
+	"tutorial",
+	"recipe",
+]
+compatibility_version = "2.0.0"
+
+[dependencies]
+codec = { version = '1.3.0', package = 'parity-scale-codec', default-features = false, features = ['derive'] }
+
+# Substrate packages
+frame-support = { version = '2.0.0', default-features = false }
+frame-system = { version = '2.0.0', default-features = false }
+sp-runtime = { version = '2.0.0', default-features = false }
+sp-std = { version = '2.0.0', default-features = false }
+
+# local packages
+account-set = { path = '../../../traits/account-set', default-features = false }
+
+[dev-dependencies]
+sp-core = { version = '2.0.0', default-features = false }
+sp-io = { version = '2.0.0', default-features = false }
+
+[features]
+default = ['std']
+std = [
+    'account-set/std',
+    'codec/std',
+    'frame-support/std',
+    'frame-system/std',
+    'sp-runtime/std',
+]

--- a/pallets/membership/supernodes/src/lib.rs
+++ b/pallets/membership/supernodes/src/lib.rs
@@ -1,0 +1,134 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+//! A pallet that implements a storage set on top of a sorted vec and demonstrates performance
+//! tradeoffs when using map sets.
+
+use account_set::AccountSet;
+use frame_support::{
+    decl_error,
+    decl_event,
+    decl_module,
+    decl_storage,
+    dispatch::DispatchResult,
+    ensure,
+};
+use frame_system::{
+    self as system,
+    ensure_root,
+};
+use sp_std::{
+    collections::btree_set::BTreeSet,
+    prelude::*,
+};
+
+#[cfg(test)]
+mod tests;
+
+/// A maximum number of members. When membership reaches this number, no new members may join.
+pub const MAX_MEMBERS: usize = 16;
+
+pub trait Trait: system::Trait {
+    type Event: From<Event<Self>> + Into<<Self as system::Trait>::Event>;
+}
+
+decl_storage! {
+    trait Store for Module<T: Trait> as VecSet {
+        // The set of all members. Stored as a single vec
+        Members get(fn members): Vec<T::AccountId>;
+    }
+}
+
+decl_event!(
+    pub enum Event<T>
+    where
+        AccountId = <T as system::Trait>::AccountId,
+    {
+        /// Added a member
+        MemberAdded(AccountId),
+        /// Removed a member
+        MemberRemoved(AccountId),
+    }
+);
+
+decl_error! {
+    pub enum Error for Module<T: Trait> {
+        /// Cannot join as a member because you are already a member
+        AlreadyMember,
+        /// Cannot give up membership because you are not currently a member
+        NotMember,
+        /// Cannot add another member because the limit is already reached
+        MembershipLimitReached,
+    }
+}
+
+decl_module! {
+    pub struct Module<T: Trait> for enum Call where origin: T::Origin {
+        fn deposit_event() = default;
+
+        type Error = Error<T>;
+
+        /// Adds a member to the membership set unless the max is reached
+        #[weight = 10_000]
+        pub fn add_member(
+            origin,
+            new_member: T::AccountId,
+        ) -> DispatchResult {
+            // let _sender = ensure_root(origin)?;
+            let _sender = ensure_root(origin)?;
+
+            let mut members = Members::<T>::get();
+            ensure!(members.len() < MAX_MEMBERS, Error::<T>::MembershipLimitReached);
+
+            // We don't want to add duplicate members, so we check whether the potential new
+            // member is already present in the list. Because the list is always ordered, we can
+            // leverage the binary search which makes this check O(log n).
+            match members.binary_search(&new_member) {
+                // If the search succeeds, the caller is already a member, so just return
+                Ok(_) => Err(Error::<T>::AlreadyMember.into()),
+                // If the search fails, the caller is not a member and we learned the index where
+                // they should be inserted
+                Err(index) => {
+                    members.insert(index, new_member.clone());
+                    Members::<T>::put(members);
+                    Self::deposit_event(RawEvent::MemberAdded(new_member));
+                    Ok(())
+                }
+            }
+        }
+
+        /// Removes a member.
+        #[weight = 10_000]
+        pub fn remove_member(
+            origin,
+            old_member: T::AccountId,
+        ) -> DispatchResult {
+            // let _sender = ensure_root(origin)?;
+            let _sender = ensure_root(origin)?;
+
+            let mut members = Members::<T>::get();
+
+            // We have to find out if the member exists in the sorted vec, and, if so, where.
+            match members.binary_search(&old_member) {
+                // If the search succeeds, the caller is a member, so remove her
+                Ok(index) => {
+                    members.remove(index);
+                    Members::<T>::put(members);
+                    Self::deposit_event(RawEvent::MemberRemoved(old_member));
+                    Ok(())
+                },
+                // If the search fails, the caller is not a member, so just return
+                Err(_) => Err(Error::<T>::NotMember.into()),
+            }
+        }
+
+        // also see `append_or_insert`, `append_or_put` in pallet-elections/phragmen, democracy
+    }
+}
+
+impl<T: Trait> AccountSet for Module<T> {
+    type AccountId = T::AccountId;
+
+    fn accounts() -> BTreeSet<T::AccountId> {
+        Self::members().into_iter().collect::<BTreeSet<_>>()
+    }
+}

--- a/pallets/membership/supernodes/src/lib.rs
+++ b/pallets/membership/supernodes/src/lib.rs
@@ -73,7 +73,6 @@ decl_module! {
             origin,
             new_member: T::AccountId,
         ) -> DispatchResult {
-            // let _sender = ensure_root(origin)?;
             let _sender = ensure_root(origin)?;
 
             let mut members = Members::<T>::get();
@@ -102,7 +101,6 @@ decl_module! {
             origin,
             old_member: T::AccountId,
         ) -> DispatchResult {
-            // let _sender = ensure_root(origin)?;
             let _sender = ensure_root(origin)?;
 
             let mut members = Members::<T>::get();

--- a/pallets/membership/supernodes/src/tests.rs
+++ b/pallets/membership/supernodes/src/tests.rs
@@ -1,0 +1,147 @@
+use crate::*;
+use frame_support::{
+    assert_noop,
+    assert_ok,
+    impl_outer_event,
+    impl_outer_origin,
+    parameter_types,
+};
+use frame_system as system;
+use sp_core::H256;
+use sp_io::TestExternalities;
+use sp_runtime::{
+    testing::Header,
+    traits::{
+        BlakeTwo256,
+        IdentityLookup,
+    },
+    Perbill,
+};
+
+impl_outer_origin! {
+    pub enum Origin for TestRuntime {}
+}
+
+// Workaround for https://github.com/rust-lang/rust/issues/26925 . Remove when sorted.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct TestRuntime;
+parameter_types! {
+    pub const BlockHashCount: u64 = 250;
+    pub const MaximumBlockWeight: u32 = 1024;
+    pub const MaximumBlockLength: u32 = 2 * 1024;
+    pub const AvailableBlockRatio: Perbill = Perbill::one();
+}
+impl system::Trait for TestRuntime {
+    type AccountData = ();
+    type AccountId = u64;
+    type AvailableBlockRatio = AvailableBlockRatio;
+    type BaseCallFilter = ();
+    type BlockExecutionWeight = ();
+    type BlockHashCount = BlockHashCount;
+    type BlockNumber = u64;
+    type Call = ();
+    type DbWeight = ();
+    type Event = TestEvent;
+    type ExtrinsicBaseWeight = ();
+    type Hash = H256;
+    type Hashing = BlakeTwo256;
+    type Header = Header;
+    type Index = u64;
+    type Lookup = IdentityLookup<Self::AccountId>;
+    type MaximumBlockLength = MaximumBlockLength;
+    type MaximumBlockWeight = MaximumBlockWeight;
+    type MaximumExtrinsicWeight = MaximumBlockWeight;
+    type OnKilledAccount = ();
+    type OnNewAccount = ();
+    type Origin = Origin;
+    type PalletInfo = ();
+    type SystemWeightInfo = ();
+    type Version = ();
+}
+
+mod vec_set {
+    pub use crate::Event;
+}
+
+impl_outer_event! {
+    pub enum TestEvent for TestRuntime {
+        vec_set<T>,
+        system<T>,
+    }
+}
+
+impl Trait for TestRuntime {
+    type Event = TestEvent;
+}
+
+pub type System = system::Module<TestRuntime>;
+pub type VecSet = Module<TestRuntime>;
+
+struct ExternalityBuilder;
+
+impl ExternalityBuilder {
+    pub fn build() -> TestExternalities {
+        let storage = system::GenesisConfig::default().build_storage::<TestRuntime>().unwrap();
+        let mut ext = TestExternalities::from(storage);
+        ext.execute_with(|| System::set_block_number(1));
+        ext
+    }
+}
+
+#[test]
+fn add_member_works() {
+    ExternalityBuilder::build().execute_with(|| {
+        assert_ok!(VecSet::add_member(Origin::signed(1), 2));
+
+        let expected_event = TestEvent::vec_set(RawEvent::MemberAdded(2));
+
+        assert_eq!(System::events()[0].event, expected_event,);
+
+        assert_eq!(VecSet::members(), vec![2]);
+    })
+}
+
+#[test]
+fn cant_add_duplicate_members() {
+    ExternalityBuilder::build().execute_with(|| {
+        assert_ok!(VecSet::add_member(Origin::signed(1), 2));
+
+        assert_noop!(VecSet::add_member(Origin::signed(1), 2), Error::<TestRuntime>::AlreadyMember);
+    })
+}
+
+#[test]
+fn cant_exceed_max_members() {
+    ExternalityBuilder::build().execute_with(|| {
+        // Add 16 members, reaching the max
+        for i in 0..16 {
+            assert_ok!(VecSet::add_member(Origin::signed(i), i));
+        }
+
+        // Try to add the 17th member exceeding the max
+        assert_noop!(VecSet::add_member(Origin::signed(16), 16), Error::<TestRuntime>::MembershipLimitReached);
+    })
+}
+
+#[test]
+fn remove_member_works() {
+    ExternalityBuilder::build().execute_with(|| {
+        assert_ok!(VecSet::add_member(Origin::signed(1), 2));
+        assert_ok!(VecSet::remove_member(Origin::signed(1), 2));
+
+        // check correct event emission
+        let expected_event = TestEvent::vec_set(RawEvent::MemberRemoved(2));
+        assert!(System::events().iter().any(|a| a.event == expected_event));
+
+        // check storage changes
+        assert_eq!(VecSet::members(), Vec::<u64>::new());
+    })
+}
+
+#[test]
+fn remove_member_handles_errors() {
+    ExternalityBuilder::build().execute_with(|| {
+        // 2 is NOT previously added as a member
+        assert_noop!(VecSet::remove_member(Origin::signed(2), 2), Error::<TestRuntime>::NotMember);
+    })
+}

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -54,6 +54,7 @@ std = [
     'roaming-billing-policies/std',
     'roaming-charging-policies/std',
     'roaming-packet-bundles/std',
+    'membership-supernodes/std',
     'mining-config-token/std',
     'mining-config-hardware/std',
     'mining-rates-token/std',
@@ -120,6 +121,7 @@ roaming-sessions = { default_features = false, package = 'roaming-sessions', pat
 roaming-billing-policies = { default_features = false, package = 'roaming-billing-policies', path = '../pallets/roaming/roaming-billing-policies' }
 roaming-charging-policies = { default_features = false, package = 'roaming-charging-policies', path = '../pallets/roaming/roaming-charging-policies' }
 roaming-packet-bundles = { default_features = false, package = 'roaming-packet-bundles', path = '../pallets/roaming/roaming-packet-bundles' }
+membership-supernodes = { default_features = false, package = 'membership-supernodes', path = '../pallets/membership/supernodes' }
 mining-config-token = { default_features = false, package = 'mining-config-token', path = '../pallets/mining/config/token' }
 mining-config-hardware = { default_features = false, package = 'mining-config-hardware', path = '../pallets/mining/config/hardware' }
 mining-rates-token = { default_features = false, package = 'mining-rates-token', path = '../pallets/mining/rates/token' }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -74,6 +74,7 @@ pub use frame_support::{
     },
     StorageValue,
 };
+pub use membership_supernodes;
 pub use pallet_balances::Call as BalancesCall;
 pub use pallet_staking::StakerStatus;
 pub use pallet_timestamp::Call as TimestampCall;
@@ -715,6 +716,10 @@ impl exchange_rate::Trait for Runtime {
     type IOTARate = u64;
 }
 
+impl membership_supernodes::Trait for Runtime {
+    type Event = Event;
+}
+
 // Create the runtime by composing the FRAME pallets that were previously configured.
 construct_runtime!(
     pub enum Runtime where
@@ -736,6 +741,7 @@ construct_runtime!(
         PalletTreasury: pallet_treasury::{Module, Call, Storage, Config, Event<T>},
         Session: pallet_session::{Module, Call, Storage, Event, Config<T>},
         Staking: pallet_staking::{Module, Call, Config<T>, Storage, Event<T>},
+        MembershipSupernodes: membership_supernodes::{Module, Call, Storage, Event<T>},
         RoamingOperators: roaming_operators::{Module, Call, Storage, Event<T>},
         RoamingNetworks: roaming_networks::{Module, Call, Storage, Event<T>},
         RoamingOrganizations: roaming_organizations::{Module, Call, Storage, Event<T>},

--- a/traits/account-set/Cargo.toml
+++ b/traits/account-set/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "account-set"
+version = "2.0.0"
+edition = "2018"
+authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
+repository = 'https://github.com/substrate-developer-hub/recipes'
+description = "A trait that supplies a set of accounts for use in a Substrate runtime"
+license = "GPL-3.0-or-later"
+
+[package.metadata.substrate]
+categories = [
+	"trait",
+	"accounts",
+	"recipe",
+]
+compatibility_version = "2.0.0"
+
+[features]
+default = ['std']
+std = [
+	'sp-std/std',
+]
+
+[dependencies]
+# Substrate packages
+sp-std = { version = '2.0.0', default-features = false }

--- a/traits/account-set/src/lib.rs
+++ b/traits/account-set/src/lib.rs
@@ -1,0 +1,11 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use sp_std::collections::btree_set::BTreeSet;
+
+/// Types that implement the AccountSet trait are able to supply a set of accounts
+/// The trait is generic over the notion of Account used.
+pub trait AccountSet {
+    type AccountId;
+
+    fn accounts() -> BTreeSet<Self::AccountId>;
+}


### PR DESCRIPTION
This creates a membership, where only the Sudo user may add/remove different accounts from being a member

It's basically just an implementation of https://substrate.dev/recipes/pallet-coupling.html#loose-coupling in our code.

Almost the entire pallet code is from here https://github.com/substrate-developer-hub/recipes/tree/master/pallets/vec-set

I've just added `ensure_root` instead of `ensure_signed` so only Sudo user can add/remove members