### PR TITLE
fix: Fixes #186 Update custom types to be compatible with latest polkadot.js API

### DIFF
--- a/custom_types.json
+++ b/custom_types.json
@@ -1,5 +1,6 @@
 {
   "Date": "i64",
+  "AccountInfo": "AccountInfoWithDualRefCount",
   "Keys": "SessionKeys2",
   "Address": "MultiAddress",
   "LookupSource": "MultiAddress",


### PR DESCRIPTION
update custom types to be compatible with latest polkadot.js by adding `"AccountInfo": "AccountInfoWithDualRefCount"` based on this comment by Jaco "API defaults to triple refcount, your chain seemd to have the old-style double (no sufficients, hence the 4 bytes missing). So add your correct AccountInfo type for your chain". this happened after update JS API to 4.9.3-15 https://matrix.to/#/!HzySYSaIhtyWrwiwEV:matrix.org/$162083712644936xJfyi:matrix.parity.io?via=matrix.parity.io&via=matrix.org&via=corepaper.org