### PR TITLE
feat: Relates to #211. Upgrade to v3.0.6. Spec version 9. Democracy pallet with faster proposal and voting parameters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1171,7 +1171,7 @@ dependencies = [
 
 [[package]]
 name = "datahighway"
-version = "3.0.4"
+version = "3.0.6"
 dependencies = [
  "datahighway-runtime",
  "frame-benchmarking",
@@ -1229,7 +1229,7 @@ dependencies = [
 
 [[package]]
 name = "datahighway-runtime"
-version = "3.0.4"
+version = "3.0.6"
 dependencies = [
  "chrono",
  "exchange-rate",
@@ -3579,7 +3579,7 @@ dependencies = [
 
 [[package]]
 name = "mining-eligibility-proxy"
-version = "3.0.4"
+version = "3.0.6"
 dependencies = [
  "account-set",
  "chrono",
@@ -3848,7 +3848,7 @@ dependencies = [
 
 [[package]]
 name = "module-primitives"
-version = "3.0.4"
+version = "3.0.6"
 dependencies = [
  "bitmask",
  "parity-scale-codec",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -3,7 +3,7 @@ authors = ['MXC Foundation gGmbH <https://t.me/mxcfoundation>', 'Luke Schoen <lu
 build = 'build.rs'
 edition = '2018'
 name = 'datahighway'
-version = '3.0.5'
+version = '3.0.6'
 
 [[bin]]
 name = 'datahighway'
@@ -22,12 +22,12 @@ structopt = '0.3.8'
 hex-literal = '0.3.1'
 
 # local node-specific dependencies
-datahighway-runtime = { version = '3.0.5', path = '../runtime' }
+datahighway-runtime = { version = '3.0.6', path = '../runtime' }
 
 # Substrate dependencies
 frame-benchmarking = '3.1.0'
 frame-benchmarking-cli = '3.0.0'
-module-primitives = { version = '3.0.5', default-features = false, path = '../pallets/primitives' }
+module-primitives = { version = '3.0.6', default-features = false, path = '../pallets/primitives' }
 pallet-authority-discovery = '3.0.0'
 pallet-democracy = '3.0.0'
 pallet-im-online = '3.0.0'

--- a/pallets/mining/eligibility/proxy/Cargo.toml
+++ b/pallets/mining/eligibility/proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mining-eligibility-proxy"
-version = "3.0.5"
+version = "3.0.6"
 authors = ["Luke Schoen"]
 edition = "2018"
 
@@ -31,7 +31,7 @@ std = [
 codec = { version = '2.0.0', package = 'parity-scale-codec', default-features = false, features = ['derive'] }
 frame-support = { version = '3.0.0', default-features = false }
 frame-system = { version = '3.0.0', default-features = false }
-module-primitives = { version = '3.0.5', default-features = false, path = '../../../primitives' }
+module-primitives = { version = '3.0.6', default-features = false, path = '../../../primitives' }
 safe-mix = { version = '1.0.0', default-features = false }
 pallet-balances = { version = '3.0.0', default-features = false }
 pallet-randomness-collective-flip = { version = '3.0.0', default-features = false }

--- a/pallets/primitives/Cargo.toml
+++ b/pallets/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'module-primitives'
-version = '3.0.5'
+version = '3.0.6'
 authors = ['Laminar Developers <hello@laminar.one>', 'MXC Foundation GmbH <https://t.me/mxcfoundation>', 'Luke Schoen']
 edition = '2018'
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ['MXC Foundation gGmbH <https://t.me/mxcfoundation>', 'Luke Schoen <luke@mxc.org>', 'Ilya Beregovskiy <ilya@mxc.org>']
 edition = '2018'
 name = 'datahighway-runtime'
-version = '3.0.5'
+version = '3.0.6'
 
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -197,7 +197,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("datahighway"),
     impl_name: create_runtime_str!("datahighway"),
     authoring_version: 2,
-    spec_version: 8,
+    spec_version: 9,
     impl_version: 2,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 2,
@@ -807,13 +807,13 @@ impl pallet_staking::Config for Runtime {
 }
 
 parameter_types! {
-    pub const LaunchPeriod: BlockNumber = 28 * 24 * 60 * MINUTES;
-    pub const VotingPeriod: BlockNumber = 28 * 24 * 60 * MINUTES;
-    pub const FastTrackVotingPeriod: BlockNumber = 3 * 24 * 60 * MINUTES;
+    pub const LaunchPeriod: BlockNumber = 5 * MINUTES;
+    pub const VotingPeriod: BlockNumber = 5 * MINUTES;
+    pub const FastTrackVotingPeriod: BlockNumber = 3 * MINUTES;
     pub const InstantAllowed: bool = true;
     pub const MinimumDeposit: Balance = 100 * DOLLARS;
-    pub const EnactmentPeriod: BlockNumber = 30 * 24 * 60 * MINUTES;
-    pub const CooloffPeriod: BlockNumber = 28 * 24 * 60 * MINUTES;
+    pub const EnactmentPeriod: BlockNumber = 5 * MINUTES;
+    pub const CooloffPeriod: BlockNumber = 5 * MINUTES;
     // One cent: $10,000 / MB
     pub const PreimageByteDeposit: Balance = 1 * CENTS;
     pub const MaxVotes: u32 = 100;


### PR DESCRIPTION
Changes necessary to perform a forkless chain upgrade so that the community may use on-chain voting to propose to transfer DHX tokens from the DHX DAO Unlocked Reserves (Treasury) to a Multisig Proxy account for subsequent transfer to topup a Supernode. Refer to https://github.com/DataHighway-DHX/documentation/pull/129

Steps: Test that it works on "dev" chain locally

1)  Generate Wasm file to use later for forkless upgrade
* Checkout this branch 'luke/1288-upgrade-democracy-faster' and build it to generate a Wasm file of v3.0.6 where democracy parameters are faster for forkless upgrade (i.e. launch period, voting period, and cooling off period of only 5 minutes instead of 28 days; enactment period of 5 mins instead of 30 days; fast track voting period of 4 minutes instead of 3 days)
```
git fetch origin luke/1288-upgrade-democracy-faster:luke/1288-upgrade-democracy-faster
git checkout luke/1288-upgrade-democracy-faster
cargo build --release
```
* Copy the generated Wasm file from ~/code/DataHighway-DHX/node/target/release/wbuild/datahighway-runtime.wasm

2) Run existing chain and generate an on-chain governance proposal to transfer tokens between two accounts that will use sudo
* Checkout 'master' branch which is v3.0.5 and build it
```
git checkout master
cargo build --release
```
* Run the "dev" chain with v3.0.5
```
rm -rf /tmp/polkadot-chains/ &&
./target/release/datahighway \                    
  --base-path /tmp/polkadot-chains/alice \
  --name "Data Highway Development Chain" \
  --dev \
  --telemetry-url "wss://telemetry.polkadot.io/submit/ 0" \
  -lruntime=debug
```
* Go to https://polkadot.js.org/apps/?rpc=ws%3A%2F%2F127.0.0.1%3A9944#/accounts
  * Observe that it's using v8 and genesis initiated with 3.0.5
  * Observe that Alice & Bob's balance are both 10 DEV tokens
* Follow the steps in the documentation https://github.com/DataHighway-DHX/documentation/pull/129/files
  * i.e. generate a preimage to transfer 1 DEV from Alice to Bob, using "balances > forceTransfer", copy the preimage hash and then use it to create a proposal, then second the proposal. note that the launch period shown in the UI is 28 days at https://polkadot.js.org/apps/?rpc=ws%3A%2F%2F127.0.0.1%3A9944#/democracy

3) On-chain upgrade to faster democracy
* Use sudo to upgrade the runtime following this guide https://substrate.dev/docs/en/tutorials/forkless-upgrade/sudo-upgrade
  * Note: In future we can use on-chain governance to upgrade the runtime as the democracy launch and voting periods will be only 5 mins instead of 28 days, and we'll follow this guide https://github.com/DataHighway-DHX/documentation/pull/127/files
* After the sudo upgrade, the UI changes from v8 to v9, but still shows v3.0.5 since that was the version at genesis chain (then on-chain upgrade to v3.0.6)
* Go to "overview" at https://polkadot.js.org/apps/?rpc=ws%3A%2F%2F127.0.0.1%3A9944#/democracy
  * Observe that Launch Period still shown as 26 d 4 hrs in UI, even though we just did an upgrade to reduce it to 5 mins
  * The previous "proposal" that we created prior to the forkless upgrade that was seconded has now changed from being listed in the "proposal" section to the "referenda" section (since it has already satisfied the duration required by the new runtime parameters), and has only ~4 mins remaining for voting, and ~9 mins to activate.
  * Vote "Yey" on the referenda
  * Wait ~4 minutes for the voting period to end, then it disappears from "referenda" section, and is added to scheduled "dispatch" queue.
  * Go to "dispatch" tab to view it at https://polkadot.js.org/apps/?rpc=ws%3A%2F%2F127.0.0.1%3A9944#/democracy/dispatch
  * Wait a further 4 mins for it to enact the proposal from the referendum
  * Check that the balance has been transferred using Sudo in the "accounts" tab https://polkadot.js.org/apps/?rpc=ws%3A%2F%2F127.0.0.1%3A9944#/accounts
  
Important: this is still a Sudo transfer, so must only be used between the Treasury and Multisig Proxy. Only normal transfer is allowed between Multisig Proxy and Supernode (since Supernode will not accept transfers using Sudo)


