### PR TITLE
feat: MMD-1309 10-to-1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -786,9 +786,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cf2cc85830eae84823884db23c5306442a6c3d5bfd3beb2f2a2c829faa1816"
+checksum = "10612c0ec0e0a1ff0e97980647cb058a6e7aedb913d01d009c406b8b7d0b26ee"
 dependencies = [
  "glob",
  "libc",
@@ -1216,6 +1216,7 @@ dependencies = [
  "mining-execution-token",
  "mining-rates-hardware",
  "mining-rates-token",
+ "mining-rewards-allowance",
  "mining-sampling-hardware",
  "mining-sampling-token",
  "mining-setting-hardware",
@@ -1588,9 +1589,9 @@ dependencies = [
 
 [[package]]
 name = "finality-grandpa"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c832d0ed507622c7cb98e9b7f10426850fc9d38527ab8071778dcc3a81d45875"
+checksum = "e8ac3ff5224ef91f3c97e03eb1de2db82743427e91aaa5ac635f454f0b164f5a"
 dependencies = [
  "either",
  "futures 0.3.17",
@@ -2345,9 +2346,9 @@ dependencies = [
 
 [[package]]
 name = "if-addrs"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28538916eb3f3976311f5dfbe67b5362d0add1293d0a9cad17debf86f8e3aa48"
+checksum = "c9a83ec4af652890ac713ffd8dc859e650420a5ef47f7b9be29b6664ab50fbc8"
 dependencies = [
  "if-addrs-sys",
  "libc",
@@ -3686,6 +3687,24 @@ dependencies = [
  "parity-scale-codec",
  "roaming-operators",
  "safe-mix",
+ "serde",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "mining-rewards-allowance"
+version = "3.0.6"
+dependencies = [
+ "chrono",
+ "frame-support",
+ "frame-system",
+ "log",
+ "pallet-balances",
+ "pallet-timestamp",
+ "parity-scale-codec",
  "serde",
  "sp-core",
  "sp-io",
@@ -5206,9 +5225,9 @@ dependencies = [
 
 [[package]]
 name = "pwasm-utils"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c1a2f10b47d446372a4f397c58b329aaea72b2daf9395a623a411cb8ccb54f"
+checksum = "880b3384fb00b8f6ecccd5d358b93bd2201900ae3daad213791d1864f6441f5c"
 dependencies = [
  "byteorder",
  "log",
@@ -6881,9 +6900,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info"
-version = "0.10.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e62ff266e136db561a007c84569985805f84a1d5a08278e52c36aacb6e061b"
+checksum = "5c55b744399c25532d63a0d2789b109df8d46fc93752d46b0782991a931a782f"
 dependencies = [
  "bitvec 0.20.4",
  "cfg-if 1.0.0",
@@ -6894,9 +6913,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info-derive"
-version = "0.7.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b648fa291891a4c80187a25532f6a7d96b82c70353e30b868b14632b8fe043d6"
+checksum = "baeb2780690380592f86205aa4ee49815feb2acad8c2f59e6dd207148c3f1fcd"
 dependencies = [
  "proc-macro-crate 1.0.0",
  "proc-macro2",
@@ -8054,9 +8073,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.75"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f58f7e8eaa0009c5fec437aabf511bd9933e4b2d7407bd05273c01a8906ea7"
+checksum = "c6f107db402c2c2055242dbf4d2af0e69197202e9faacbef9571bbe47f5a1b84"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8121,18 +8140,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "283d5230e63df9608ac7d9691adc1dfb6e701225436eb64d0b9a7f0a5a04f6ec"
+checksum = "602eca064b2d83369e2b2f34b09c70b605402801927c65c11071ac911d299b88"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa3884228611f5cd3608e2d409bf7dce832e4eb3135e3f11addbd7e41bd68e71"
+checksum = "bad553cc2c78e8de258400763a647e80e6d1b31ee237275d756f6836d204494c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8252,9 +8271,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1caa0b0c8d94a049db56b5acf8cba99dc0623aab1b26d5b5f5e2d945846b3592"
+checksum = "08d3725d3efa29485e87311c5b699de63cde14b00ed4d256b8318aa30ca452cd"
 dependencies = [
  "bytes 1.1.0",
  "futures-core",
@@ -8448,9 +8467,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
+checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
 
 [[package]]
 name = "ucd-trie"

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -16,6 +16,7 @@ use datahighway_runtime::{
     GrandpaConfig,
     ImOnlineConfig,
     IndicesConfig,
+    MiningRewardsAllowanceConfig,
     SessionConfig,
     SessionKeys,
     StakerStatus,
@@ -913,6 +914,10 @@ fn testnet_genesis(
         grandpa: GrandpaConfig {
             authorities: vec![],
         },
+        mining_rewards_allowance: MiningRewardsAllowanceConfig {
+            rewards_allowance_dhx_current: 5_000_000_000_000_000_000_000u128,
+            rewards_allowance_dhx_for_date: Default::default(),
+        },
         // pallet_membership_Instance1
         technical_membership: TechnicalMembershipConfig {
             members: vec![root_key.clone()],
@@ -1004,6 +1009,10 @@ fn mainnet_genesis(
 		},
         grandpa: GrandpaConfig {
             authorities: vec![],
+        },
+        mining_rewards_allowance: MiningRewardsAllowanceConfig {
+            rewards_allowance_dhx_current: 5_000_000_000_000_000_000_000u128,
+            rewards_allowance_dhx_for_date: Default::default(),
         },
         // pallet_membership_Instance1
         technical_membership: TechnicalMembershipConfig {

--- a/pallets/mining/rewards-allowance/Cargo.toml
+++ b/pallets/mining/rewards-allowance/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+name = "mining-rewards-allowance"
+version = "3.0.6"
+authors = ["Luke Schoen"]
+edition = "2018"
+
+[package.metadata.docs.rs]
+targets = ['x86_64-unknown-linux-gnu']
+
+[features]
+default = ['std']
+std = [
+    'chrono/std',
+    'log/std',
+    'serde/std',
+    'codec/std',
+    'frame-support/std',
+    'frame-system/std',
+    'pallet-balances/std',
+    'pallet-timestamp/std',
+    # 'pallet-transaction-payment/std',
+    'sp-core/std',
+    'sp-io/std',
+    'sp-runtime/std',
+    'sp-std/std',
+]
+
+[dependencies]
+chrono = { version = '0.4.19', default_features = false }
+log = { version = '0.4.14', default-features = false }
+serde = { version = '1.0.126', features = ['derive'] }
+codec = { version = '2.2.0', package = 'parity-scale-codec', default-features = false, features = ['derive', 'max-encoded-len'] }
+frame-support = { git = 'https://github.com/paritytech/substrate', rev = '852bab073407b65b5e3e461baaa0541c4e0bc3d6', default-features = false }
+frame-system = { git = 'https://github.com/paritytech/substrate', rev = '852bab073407b65b5e3e461baaa0541c4e0bc3d6', default-features = false }
+pallet-balances = { git = 'https://github.com/paritytech/substrate', rev = '852bab073407b65b5e3e461baaa0541c4e0bc3d6', default-features = false }
+pallet-timestamp = { git = 'https://github.com/paritytech/substrate', rev = '852bab073407b65b5e3e461baaa0541c4e0bc3d6', default_features = false }
+# pallet-transaction-payment = { git = 'https://github.com/paritytech/substrate', rev = '852bab073407b65b5e3e461baaa0541c4e0bc3d6', default-features = false }
+sp-core = { git = 'https://github.com/paritytech/substrate', rev = '852bab073407b65b5e3e461baaa0541c4e0bc3d6', default-features = false }
+sp-io = { git = 'https://github.com/paritytech/substrate', rev = '852bab073407b65b5e3e461baaa0541c4e0bc3d6', default-features = false }
+sp-runtime = { git = 'https://github.com/paritytech/substrate', rev = '852bab073407b65b5e3e461baaa0541c4e0bc3d6', default-features = false }
+sp-std = { git = 'https://github.com/paritytech/substrate', rev = '852bab073407b65b5e3e461baaa0541c4e0bc3d6', default-features = false }
+
+[dev-dependencies]
+

--- a/pallets/mining/rewards-allowance/src/lib.rs
+++ b/pallets/mining/rewards-allowance/src/lib.rs
@@ -1,0 +1,478 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+/// Edit this file to define custom logic or remove it if it is not needed.
+/// Learn more about FRAME and the core library of Substrate FRAME pallets:
+/// <https://substrate.dev/docs/en/knowledgebase/runtime/frame>
+pub use pallet::*;
+
+// #[cfg(test)]
+// mod mock;
+
+// #[cfg(test)]
+// mod tests;
+
+// #[cfg(feature = "runtime-benchmarks")]
+// mod benchmarking;
+
+#[frame_support::pallet]
+pub mod pallet {
+    use chrono::{
+        NaiveDateTime,
+    };
+    use codec::{
+        Decode,
+        Encode,
+    };
+    use frame_support::{dispatch::DispatchResult, pallet_prelude::*,
+        traits::{
+            Currency,
+        }
+    };
+    use frame_system::pallet_prelude::*;
+    use sp_std::{
+        convert::{
+            TryFrom,
+            TryInto,
+        },
+        prelude::*, // Imports Vec
+    };
+
+    // type BalanceOf<T> = <T as pallet_balances::Config>::Balance;
+    type BalanceOf<T> = <<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
+    type Date = i64;
+
+    #[derive(Encode, Decode, Debug, Default, Clone, Eq, PartialEq)]
+    #[cfg_attr(feature = "std", derive())]
+    pub struct BondedDHXForAccountData<U, V, W> {
+        pub account_id: U,
+        pub bonded_dhx_current: V,
+        pub requestor_account_id: W,
+    }
+
+    type BondedData<T> = BondedDHXForAccountData<
+        <T as frame_system::Config>::AccountId,
+        BalanceOf<T>,
+        <T as frame_system::Config>::AccountId,
+    >;
+
+    /// Configure the pallet by specifying the parameters and types on which it depends.
+    #[pallet::config]
+    pub trait Config: frame_system::Config
+        + pallet_balances::Config
+        + pallet_timestamp::Config {
+        /// Because this pallet emits events, it depends on the runtime's definition of an event.
+        type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
+        type Currency: Currency<Self::AccountId>;
+    }
+
+    #[pallet::pallet]
+    #[pallet::generate_store(pub(super) trait Store)]
+    pub struct Pallet<T>(_);
+
+    // The pallet's runtime storage items.
+    // https://substrate.dev/docs/en/knowledgebase/runtime/storage
+    #[pallet::storage]
+    #[pallet::getter(fn something)]
+    // Learn more about declaring storage items:
+    // https://substrate.dev/docs/en/knowledgebase/runtime/storage#declaring-storage-items
+    pub type Something<T> = StorageValue<_, u32>;
+
+    #[pallet::storage]
+    #[pallet::getter(fn bonded_dhx_of_account_for_date)]
+    pub(super) type BondedDHXForAccountForDate<T: Config> = StorageMap<_, Blake2_128Concat,
+        Date,
+        Option<Vec<BondedData<T>>>
+    >;
+
+    #[pallet::storage]
+    #[pallet::getter(fn rewards_allowance_dhx_for_date)]
+    pub(super) type RewardsAllowanceDHXForDate<T: Config> = StorageMap<_, Blake2_128Concat, Date, BalanceOf<T>>;
+
+    #[pallet::storage]
+    #[pallet::getter(fn rewards_allowance_dhx_current)]
+    pub(super) type RewardsAllowanceDHXCurrent<T: Config> = StorageValue<_, u128>;
+
+    // The genesis config type.
+    #[pallet::genesis_config]
+    pub struct GenesisConfig<T: Config> {
+        pub rewards_allowance_dhx_for_date: Vec<(Date, BalanceOf<T>)>,
+        pub rewards_allowance_dhx_current: u128,
+    }
+
+    // The default value for the genesis config type.
+    #[cfg(feature = "std")]
+    impl<T: Config> Default for GenesisConfig<T> {
+        fn default() -> Self {
+            Self {
+                rewards_allowance_dhx_for_date: Default::default(),
+                // 5000 UNIT, where UNIT token has 18 decimal places
+                rewards_allowance_dhx_current: 5_000_000_000_000_000_000_000u128,
+            }
+        }
+    }
+
+    // The build of genesis for the pallet.
+    #[pallet::genesis_build]
+    impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
+        fn build(&self) {
+            for (a, b) in &self.rewards_allowance_dhx_for_date {
+                <RewardsAllowanceDHXForDate<T>>::insert(a, b);
+            }
+            <RewardsAllowanceDHXCurrent<T>>::put(&self.rewards_allowance_dhx_current);
+        }
+    }
+
+    // Pallets use events to inform users when important changes are made.
+    // https://substrate.dev/docs/en/knowledgebase/runtime/events
+    #[pallet::event]
+    #[pallet::metadata(T::AccountId = "AccountId")]
+    #[pallet::generate_deposit(pub(super) fn deposit_event)]
+    pub enum Event<T: Config> {
+        /// Event documentation should end with an array that provides descriptive names for event
+        /// parameters. [something, who]
+        SomethingStored(u32, T::AccountId),
+    }
+
+    // Errors inform users that something went wrong.
+    #[pallet::error]
+    pub enum Error<T> {
+        /// Error names should be descriptive.
+        NoneValue,
+        /// Errors should have helpful documentation associated with them.
+        StorageOverflow,
+    }
+
+    // Pallet implements [`Hooks`] trait to define some logic to execute in some context.
+    #[pallet::hooks]
+    impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+        // `on_initialize` is executed at the beginning of the block before any extrinsic are
+        // dispatched.
+        //
+        // This function must return the weight consumed by `on_initialize` and `on_finalize`.
+        fn on_initialize(_n: T::BlockNumber) -> Weight {
+            // Anything that needs to be done at the start of the block.
+
+            // In the genesis config we set the default value of StorageValue `RewardsAllowanceDHXCurrent`
+            // to 5000 UNIT tokens, which would represent the total rewards to be distributed
+            // in a year. Governance may choose to change that during the year or in subsequent years.
+            //
+            // At the start of each block after genesis, we check the current timestamp
+            // (e.g. 27th August 2021 @ ~7am is 1630049371000), where milliseconds/day is 86400000,
+            // and then determine the timestamp at the start of that day (e.g. 27th August 2021 @ 12am
+            // is 1630022400000, since we want the timestamp of the start of the day to represent that
+            // day, as we will store the rewards in UNIT tokens that are available for that day
+            // as a value under that key using the `RewardsAllowanceDHXForDate` StorageMap if it does
+            // not already exist (e.g. if it was not yet generated automatically in any blocks earlier
+            // on that day, and not yet added manually by a user calling the `set_rewards_allowance_dhx_for_date`
+            // extrinsic dispatchable function).
+            //
+            // Remaining rewards available for a given day that are stored under a key that is the
+            // timestamp of that day may be modified by calling `reduce_remaining_rewards_allowance_dhx_for_date`.
+
+            // Check if current date is in storage, otherwise add it.
+            let current_date = <pallet_timestamp::Pallet<T>>::get();
+
+            let requested_date_as_u64;
+            let u64_in_millis = Self::convert_moment_to_u64_in_milliseconds(current_date.clone());
+            match u64_in_millis {
+                Err(_e) => {
+                    log::error!("Unable to convert Moment to u64 in millis for current_date");
+                    return 0;
+                },
+                Ok(ref x) => {
+                    requested_date_as_u64 = x;
+                }
+            }
+            log::info!("requested_date_as_u64: {:?}", requested_date_as_u64.clone());
+
+            let requested_date_millis;
+            let start_of_date = Self::convert_u64_in_milliseconds_to_start_of_date(requested_date_as_u64.clone());
+            match start_of_date {
+                Err(_e) => {
+                    log::error!("Unable to convert u64 millis to start of date for current_date");
+                    return 0;
+                },
+                Ok(ref x) => {
+                    requested_date_millis = x;
+                }
+            }
+
+            // https://substrate.dev/rustdocs/latest/frame_support/storage/trait.StorageMap.html
+            let contains_key = <RewardsAllowanceDHXForDate<T>>::contains_key(&requested_date_millis);
+            if contains_key == false {
+                let rewards_allowance_dhx_current_u128;
+                let dhx_to_try = <RewardsAllowanceDHXCurrent<T>>::get();
+                if let Some(_rewards_allowance_dhx_current_u128) = dhx_to_try {
+                    rewards_allowance_dhx_current_u128 = _rewards_allowance_dhx_current_u128;
+                } else {
+                    log::error!("Unable to convert Moment to i64 for requested_date");
+                    return 0;
+                }
+
+                let rewards_allowance;
+                let _rewards_allowance = Self::convert_u128_to_balance(rewards_allowance_dhx_current_u128.clone());
+                match _rewards_allowance {
+                    Err(_e) => {
+                        log::error!("Unable to convert u128 to balance for rewards_allowance");
+                        return 0;
+                    },
+                    Ok(ref x) => {
+                        rewards_allowance = x;
+                    }
+                }
+
+                // Update storage. Use RewardsAllowanceDHXCurrent as fallback incase not previously set prior to block
+                <RewardsAllowanceDHXForDate<T>>::insert(requested_date_millis.clone(), &rewards_allowance);
+                log::info!("on_initialize");
+                log::info!("requested_date_millis: {:?}", requested_date_millis.clone());
+                log::info!("rewards_allowance: {:?}", &rewards_allowance);
+            }
+
+            return 0;
+        }
+
+        // `on_finalize` is executed at the end of block after all extrinsic are dispatched.
+        fn on_finalize(_n: T::BlockNumber) {
+            // Perform necessary data/state clean up here.
+        }
+    }
+
+    // Dispatchable functions allows users to interact with the pallet and invoke state changes.
+    // These functions materialize as "extrinsics", which are often compared to transactions.
+    // Dispatchable functions must be annotated with a weight and must return a DispatchResult.
+    #[pallet::call]
+    impl<T: Config> Pallet<T> {
+        // customised by governance at any time. this function allows us to change it each year
+        // https://docs.google.com/spreadsheets/d/1W2AzOH9Cs9oCR8UYfYCbpmd9X7hp-USbYXL7AuwMY_Q/edit#gid=970997021
+        #[pallet::weight(10_000 + T::DbWeight::get().writes(1))]
+        pub fn set_bonded_dhx_of_account_for_date(origin: OriginFor<T>, account_id: T::AccountId) -> DispatchResult {
+            let _who = ensure_signed(origin)?;
+
+            // Note: we DO need the following as we're using the current timestamp, rather than a function parameter.
+            let timestamp: <T as pallet_timestamp::Config>::Moment = <pallet_timestamp::Pallet<T>>::get();
+            let requested_date_as_u64 = Self::convert_moment_to_u64_in_milliseconds(timestamp.clone())?;
+            log::info!("requested_date_as_u64: {:?}", requested_date_as_u64.clone());
+
+            // convert the requested date/time to the start of that day date/time to signify that date for lookup
+            // i.e. 21 Apr @ 1420 -> 21 Apr @ 0000
+            let requested_date_millis = Self::convert_u64_in_milliseconds_to_start_of_date(requested_date_as_u64.clone())?;
+
+            // TODO - fetch from democracy or elections
+            let bonded_dhx_current_u128 = 1000u128;
+
+            let bonded_dhx_current;
+            let _bonded_dhx_current = Self::convert_u128_to_balance(bonded_dhx_current_u128.clone());
+            match _bonded_dhx_current {
+                Err(_e) => {
+                    log::error!("Unable to convert u128 to balance for bonded_dhx_current");
+                    return Err(DispatchError::Other("Unable to convert u128 to balance for bonded_dhx_current"));
+                },
+                Ok(ref x) => {
+                    bonded_dhx_current = x;
+                }
+            }
+
+            let bonded_data: BondedData<T> = BondedDHXForAccountData {
+                account_id: account_id.clone(),
+                bonded_dhx_current: bonded_dhx_current.clone(),
+                requestor_account_id: _who.clone(),
+            };
+
+            // Update storage. Override the default that may have been set in on_initialize
+            <RewardsAllowanceDHXForDate<T>>::insert(requested_date_millis.clone(), &bonded_data);
+            log::info!("account_id: {:?}", &account_id);
+            log::info!("bonded_data: {:?}", &bonded_data);
+
+            // Emit an event.
+            // TODO
+
+            // Return a successful DispatchResultWithPostInfo
+            Ok(())
+        }
+
+        // customised by governance at any time
+        #[pallet::weight(10_000 + T::DbWeight::get().writes(1))]
+        pub fn set_rewards_allowance_dhx_current(origin: OriginFor<T>, rewards_allowance: BalanceOf<T>) -> DispatchResult {
+            let _who = ensure_signed(origin)?;
+
+            let rewards_allowance_as_u128 = Self::convert_balance_to_u128(rewards_allowance.clone())?;
+
+            // Update storage
+            <RewardsAllowanceDHXCurrent<T>>::put(&rewards_allowance_as_u128);
+            log::info!("rewards_allowance: {:?}", &rewards_allowance_as_u128);
+
+            // Emit an event.
+            // TODO
+
+            // Return a successful DispatchResultWithPostInfo
+            Ok(())
+        }
+
+        // customised by governance at any time. this function allows us to change it each year
+        // https://docs.google.com/spreadsheets/d/1W2AzOH9Cs9oCR8UYfYCbpmd9X7hp-USbYXL7AuwMY_Q/edit#gid=970997021
+        #[pallet::weight(10_000 + T::DbWeight::get().writes(1))]
+        pub fn set_rewards_allowance_dhx_for_date(origin: OriginFor<T>, rewards_allowance: BalanceOf<T>, timestamp: u64) -> DispatchResult {
+            let _who = ensure_signed(origin)?;
+
+            // Note: we do not need the following as we're not using the current timestamp, rather the function parameter.
+            // let current_date = <pallet_timestamp::Pallet<T>>::get();
+            // let requested_date_as_u64 = Self::convert_moment_to_u64_in_milliseconds(timestamp.clone())?;
+            // log::info!("requested_date_as_u64: {:?}", requested_date_as_u64.clone());
+
+            // Note: to get current timestamp `<pallet_timestamp::Pallet<T>>::get()`
+            // convert the requested date/time to the start of that day date/time to signify that date for lookup
+            // i.e. 21 Apr @ 1420 -> 21 Apr @ 0000
+            let requested_date_millis = Self::convert_u64_in_milliseconds_to_start_of_date(timestamp.clone())?;
+
+            // Update storage. Override the default that may have been set in on_initialize
+            <RewardsAllowanceDHXForDate<T>>::insert(requested_date_millis.clone(), &rewards_allowance);
+            log::info!("rewards_allowance: {:?}", &rewards_allowance);
+
+            // Emit an event.
+            // TODO
+
+            // Return a successful DispatchResultWithPostInfo
+            Ok(())
+        }
+
+        #[pallet::weight(10_000 + T::DbWeight::get().writes(1))]
+        // TODO - change from `reduce_` to `change_`, and provide another parameter `change: u8`, whose value
+        // maybe 0 or 1 to represent that we want to make a corresponding decrease or increase to the remaining
+        // dhx rewards allowance for a given date.
+        pub fn reduce_remaining_rewards_allowance_dhx_for_date(origin: OriginFor<T>, daily_rewards: BalanceOf<T>, timestamp: u64) -> DispatchResult {
+            let _who = ensure_signed(origin)?;
+
+            let requested_date_millis = Self::convert_u64_in_milliseconds_to_start_of_date(timestamp.clone())?;
+
+            // https://substrate.dev/rustdocs/latest/frame_support/storage/trait.StorageMap.html
+            ensure!(<RewardsAllowanceDHXForDate<T>>::contains_key(&requested_date_millis), DispatchError::Other("Date key must exist to reduce allowance."));
+
+            let existing_allowance_to_try = <RewardsAllowanceDHXForDate<T>>::get(&requested_date_millis);
+
+            // Validate inputs so the daily_rewards is less or equal to the existing_allowance
+            let existing_allowance_as_u128;
+            if let Some(_existing_allowance_to_try) = existing_allowance_to_try.clone() {
+                existing_allowance_as_u128 = Self::convert_balance_to_u128(_existing_allowance_to_try.clone())?;
+                log::info!("existing_allowance_as_u128: {:?}", existing_allowance_as_u128.clone());
+            } else {
+                return Err(DispatchError::Other("Unable to retrieve balance from value provided"));
+            }
+
+            let daily_rewards_as_u128;
+            daily_rewards_as_u128 = Self::convert_balance_to_u128(daily_rewards.clone())?;
+            log::info!("daily_rewards_as_u128: {:?}", daily_rewards_as_u128.clone());
+
+            ensure!(daily_rewards_as_u128 > 0u128, DispatchError::Other("Daily rewards must be greater than zero"));
+            ensure!(existing_allowance_as_u128 >= daily_rewards_as_u128, DispatchError::Other("Daily rewards cannot exceed current remaining allowance"));
+
+            let new_remaining_allowance_as_u128 = existing_allowance_as_u128 - daily_rewards_as_u128;
+            let new_remaining_allowance_as_balance = Self::convert_u128_to_balance(new_remaining_allowance_as_u128.clone())?;
+
+            // Update storage
+            <RewardsAllowanceDHXForDate<T>>::mutate(
+                &requested_date_millis,
+                |allowance| {
+                    if let Some(_allowance) = allowance {
+                        *_allowance = new_remaining_allowance_as_balance.clone();
+                    }
+                    log::info!("Reduced rewards_allowance_dhx_for_date at Date: {:?}", &requested_date_millis);
+                },
+            );
+
+            // Emit an event.
+            // TODO
+
+            // Return a successful DispatchResultWithPostInfo
+            Ok(())
+        }
+
+        /// An example dispatchable that takes a singles value as a parameter, writes the value to
+        /// storage and emits an event. This function must be dispatched by a signed extrinsic.
+        #[pallet::weight(10_000 + T::DbWeight::get().writes(1))]
+        pub fn do_something(origin: OriginFor<T>, something: u32) -> DispatchResult {
+            // Check that the extrinsic was signed and get the signer.
+            // This function will return an error if the extrinsic is not signed.
+            // https://substrate.dev/docs/en/knowledgebase/runtime/origin
+            let who = ensure_signed(origin)?;
+
+            // Update storage.
+            <Something<T>>::put(something);
+
+            // Emit an event.
+            Self::deposit_event(Event::SomethingStored(something, who));
+            // Return a successful DispatchResultWithPostInfo
+            Ok(())
+        }
+
+        /// An example dispatchable that may throw a custom error.
+        #[pallet::weight(10_000 + T::DbWeight::get().reads_writes(1,1))]
+        pub fn cause_error(origin: OriginFor<T>) -> DispatchResult {
+            let _who = ensure_signed(origin)?;
+
+            // Read a value from storage.
+            match <Something<T>>::get() {
+                // Return an error if the value has not been set.
+                None => Err(Error::<T>::NoneValue)?,
+                Some(old) => {
+                    // Increment the value read from storage; will error in the event of overflow.
+                    let new = old.checked_add(1).ok_or(Error::<T>::StorageOverflow)?;
+                    // Update the value in storage with the incremented result.
+                    <Something<T>>::put(new);
+                    Ok(())
+                },
+            }
+        }
+    }
+
+    // Private functions
+
+    impl<T: Config> Pallet<T> {
+        fn convert_moment_to_u64_in_milliseconds(date: T::Moment) -> Result<u64, DispatchError> {
+            let date_as_u64_millis;
+            if let Some(_date_as_u64) = TryInto::<u64>::try_into(date).ok() {
+                date_as_u64_millis = _date_as_u64;
+            } else {
+                return Err(DispatchError::Other("Unable to convert Moment to i64 for date"));
+            }
+            return Ok(date_as_u64_millis);
+        }
+
+        fn convert_u64_in_milliseconds_to_start_of_date(date_as_u64_millis: u64) -> Result<Date, DispatchError> {
+            let date_as_u64_secs = date_as_u64_millis.clone() / 1000u64;
+            // https://docs.rs/chrono/0.4.6/chrono/naive/struct.NaiveDateTime.html#method.from_timestamp
+            let date = NaiveDateTime::from_timestamp(i64::try_from(date_as_u64_secs).unwrap(), 0).date();
+            log::info!("date_as_u64_secs: {:?}", date_as_u64_secs.clone());
+
+            let date_start_millis = date.and_hms(0, 0, 0).timestamp() * 1000;
+            log::info!("date_start_millis: {:?}", date_start_millis.clone());
+            log::info!("Timestamp requested Date: {:?}", date);
+            return Ok(date_start_millis);
+        }
+
+        fn convert_balance_to_u128(balance: BalanceOf<T>) -> Result<u128, DispatchError> {
+            let balance_as_u128;
+
+            if let Some(_balance_as_u128) = TryInto::<u128>::try_into(balance).ok() {
+                balance_as_u128 = _balance_as_u128;
+            } else {
+                return Err(DispatchError::Other("Unable to convert Balance to u128 for balance"));
+            }
+            log::info!("balance_as_u128: {:?}", balance_as_u128.clone());
+
+            return Ok(balance_as_u128);
+        }
+
+        fn convert_u128_to_balance(balance_as_u128: u128) -> Result<BalanceOf<T>, DispatchError> {
+            let balance;
+
+            if let Some(_balance) = TryInto::<BalanceOf<T>>::try_into(balance_as_u128).ok() {
+                balance = _balance;
+            } else {
+                return Err(DispatchError::Other("Unable to convert u128 to Balance for balance"));
+            }
+            log::info!("balance: {:?}", balance.clone());
+
+            return Ok(balance);
+        }
+    }
+}

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -93,6 +93,7 @@ mining-setting-token = { default-features = false, package = 'mining-setting-tok
 mining-setting-hardware = { default-features = false, package = 'mining-setting-hardware', path = '../pallets/mining/setting/hardware' }
 mining-rates-token = { default-features = false, package = 'mining-rates-token', path = '../pallets/mining/rates/token' }
 mining-rates-hardware = { default-features = false, package = 'mining-rates-hardware', path = '../pallets/mining/rates/hardware' }
+mining-rewards-allowance = { default-features = false, package = 'mining-rewards-allowance', path = '../pallets/mining/rewards-allowance' }
 mining-sampling-token = { default-features = false, package = 'mining-sampling-token', path = '../pallets/mining/sampling/token' }
 mining-sampling-hardware = { default-features = false, package = 'mining-sampling-hardware', path = '../pallets/mining/sampling/hardware' }
 mining-eligibility-token = { default-features = false, package = 'mining-eligibility-token', path = '../pallets/mining/eligibility/token' }
@@ -178,6 +179,7 @@ std = [
     'mining-setting-hardware/std',
     'mining-rates-token/std',
     'mining-rates-hardware/std',
+    'mining-rewards-allowance/std',
     'mining-sampling-token/std',
     'mining-sampling-hardware/std',
     'mining-eligibility-token/std',

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1146,6 +1146,11 @@ impl mining_execution_token::Config for Runtime {
     type MiningExecutionTokenIndex = u64;
 }
 
+impl mining_rewards_allowance::Config for Runtime {
+    type Event = Event;
+    type Currency = Balances;
+}
+
 impl exchange_rate::Config for Runtime {
     type DOTRate = u64;
     type DecimalsAfterPoint = u32;
@@ -1217,6 +1222,7 @@ construct_runtime!(
         MiningSettingHardware: mining_setting_hardware::{Pallet, Call, Storage, Event<T>},
         MiningRatesToken: mining_rates_token::{Pallet, Call, Storage, Event<T>},
         MiningRatesHardware: mining_rates_hardware::{Pallet, Call, Storage, Event<T>},
+        MiningRewardsAllowance: mining_rewards_allowance::{Pallet, Call, Storage, Config<T>, Event<T>},
         MiningSamplingToken: mining_sampling_token::{Pallet, Call, Storage, Event<T>},
         MiningSamplingHardware: mining_sampling_hardware::{Pallet, Call, Storage, Event<T>},
         MiningEligibilityToken: mining_eligibility_token::{Pallet, Call, Storage, Event<T>},

--- a/runtime/tests/cli_integration_tests_mining_tokens.rs
+++ b/runtime/tests/cli_integration_tests_mining_tokens.rs
@@ -6,6 +6,7 @@ extern crate mining_setting_token as mining_setting_token;
 extern crate mining_eligibility_token as mining_eligibility_token;
 extern crate mining_execution_token as mining_execution_token;
 extern crate mining_rates_token as mining_rates_token;
+extern crate mining_rewards_allowance as mining_rewards_allowance;
 extern crate mining_sampling_token as mining_sampling_token;
 extern crate roaming_operators as roaming_operators;
 
@@ -108,6 +109,10 @@ mod tests {
         MiningSamplingTokenSetting,
         Module as MiningSamplingTokenModule,
         Config as MiningSamplingTokenConfig,
+    };
+    use mining_rewards_allowance::{
+        Module as MiningRewardsAllowanceModule,
+        Config as MiningRewardsAllowanceConfig,
     };
     use roaming_operators;
 
@@ -342,6 +347,10 @@ mod tests {
     impl MembershipSupernodesConfig for Test {
         type Event = ();
     }
+    impl MiningRewardsAllowanceConfig for Test {
+        type Event = ();
+        type Currency = Balances;
+    }
 
     pub type MiningSettingTokenTestModule = MiningSettingTokenModule<Test>;
     pub type MiningRatesTokenTestModule = MiningRatesTokenModule<Test>;
@@ -351,6 +360,7 @@ mod tests {
     pub type MiningClaimsTokenTestModule = MiningClaimsTokenModule<Test>;
     pub type MiningExecutionTokenTestModule = MiningExecutionTokenModule<Test>;
     pub type MembershipSupernodesTestModule = MembershipSupernodesModule<Test>;
+    pub type MiningRewardsAllowanceTestModule = MiningRewardsAllowanceModule<Test>;
     type Randomness = pallet_randomness_collective_flip::Pallet<Test>;
     type MembershipSupernodes = membership_supernodes::Module<Test>;
 
@@ -895,6 +905,29 @@ mod tests {
             );
 
             System::set_block_number(500);
+
+            System::set_block_number(1);
+
+            // 27th August 2021 @ ~7am is 1630049371000
+            // where milliseconds/day         86400000
+            // 27th August 2021 @ 12am is 1630022400000 (start of day)
+            Timestamp::set_timestamp(1630049371000u64);
+
+            assert_ok!(MiningRewardsAllowanceTestModule::set_rewards_allowance_dhx_current(
+                Origin::signed(0),
+                5_000u64
+            ));
+
+            assert_ok!(MiningRewardsAllowanceTestModule::set_rewards_allowance_dhx_for_date(
+                Origin::signed(0),
+                5_000u64,
+                1630049371000
+            ));
+
+            // Verify Storage
+            assert_eq!(MiningRewardsAllowanceTestModule::rewards_allowance_dhx_current(), Some(5_000_000_000_000_000_000_000u128));
+
+            assert_eq!(MiningRewardsAllowanceTestModule::rewards_allowance_dhx_for_date(1630022400000), Some(5_000u64));
         });
     }
 }


### PR DESCRIPTION
Note: To debug this branch run the following:

* Clone branch and build
```
git fetch origin luke/rewards-allowance-new:luke/rewards-allowance-new
git checkout luke/rewards-allowance-new
curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
rustup toolchain install nightly-2021-08-31
rustup default nightly-2021-08-31
rustup override set nightly-2021-08-31
rustup target add wasm32-unknown-unknown --toolchain nightly-2021-08-31
cargo build --release
```

* Run integration tests after building

```
cargo test -p datahighway-runtime
```

Outstanding issues

* [ ] - Error when building with `cargo build --release`

```
error[E0277]: the trait bound `&BondedDHXForAccountData<<T as frame_system::Config>::AccountId, <<T as pallet::Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance, <T as frame_system::Config>::AccountId>: EncodeLike<<<T as pallet::Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance>` is not satisfied
   --> pallets/mining/rewards-allowance/src/lib.rs:282:84
    |
282 |             <RewardsAllowanceDHXForDate<T>>::insert(requested_date_millis.clone(), &bonded_data);
    |                                                                                    ^^^^^^^^^^^^ the trait `EncodeLike<<<T as pallet::Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance>` is not implemented for `&BondedDHXForAccountData<<T as frame_system::Config>::AccountId, <<T as pallet::Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance, <T as frame_system::Config>::AccountId>`
    |
note: required by `frame_support::pallet_prelude::StorageMap::<Prefix, Hasher, Key, Value, QueryKind, OnEmpty, MaxValues>::insert`
   --> /Users/ls2/.cargo/git/checkouts/substrate-7e08433d4c370a21/852bab0/frame/support/src/storage/types/map.rs:142:2
    |
142 |     pub fn insert<KeyArg: EncodeLike<Key>, ValArg: EncodeLike<Value>>(key: KeyArg, val: ValArg) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
help: consider introducing a `where` bound, but there might be an alternative better way to express this requirement
    |
244 |     impl<T: Config> Pallet<T> where &BondedDHXForAccountData<<T as frame_system::Config>::AccountId, <<T as pallet::Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance, <T as frame_system::Config>::AccountId>: EncodeLike<<<T as pallet::Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance> {
    |                               ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
```

* [ ] - Error when trying to run integration tests with `cargo test -p datahighway-runtime`

```
error[E0277]: the trait bound `&BondedDHXForAccountData<<T as frame_system::Config>::AccountId, <<T as pallet::Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance, <T as frame_system::Config>::AccountId>: EncodeLike<<<T as pallet::Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance>` is not satisfied
   --> pallets/mining/rewards-allowance/src/lib.rs:282:84
    |
282 |             <RewardsAllowanceDHXForDate<T>>::insert(requested_date_millis.clone(), &bonded_data);
    |                                                                                    ^^^^^^^^^^^^ the trait `EncodeLike<<<T as pallet::Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance>` is not implemented for `&BondedDHXForAccountData<<T as frame_system::Config>::AccountId, <<T as pallet::Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance, <T as frame_system::Config>::AccountId>`
    |
note: required by `frame_support::pallet_prelude::StorageMap::<Prefix, Hasher, Key, Value, QueryKind, OnEmpty, MaxValues>::insert`
   --> /Users/ls2/.cargo/git/checkouts/substrate-7e08433d4c370a21/852bab0/frame/support/src/storage/types/map.rs:142:2
    |
142 |     pub fn insert<KeyArg: EncodeLike<Key>, ValArg: EncodeLike<Value>>(key: KeyArg, val: ValArg) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
help: consider introducing a `where` bound, but there might be an alternative better way to express this requirement
    |
244 |     impl<T: Config> Pallet<T> where &BondedDHXForAccountData<<T as frame_system::Config>::AccountId, <<T as pallet::Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance, <T as frame_system::Config>::AccountId>: EncodeLike<<<T as pallet::Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance> {
    |                               ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
```
